### PR TITLE
Handle network errors in LinkedIn scraper

### DIFF
--- a/tests/test_linkedin_scraper.py
+++ b/tests/test_linkedin_scraper.py
@@ -1,0 +1,21 @@
+import requests
+import pytest
+import os
+import sys
+
+# Ensure the repository root is on the Python path for imports
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scraper.linkedin_scraper import LinkedInScraper
+
+
+def test_scrape_jobs_handles_request_exception(monkeypatch):
+    scraper = LinkedInScraper()
+
+    def mock_get(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    result = scraper.scrape_jobs("anything")
+    assert result == []


### PR DESCRIPTION
## Summary
- avoid crashing when LinkedIn cannot be reached by catching `requests` errors and returning an empty list
- return inserted listings from `scrape_jobs`
- add regression test for network failure handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894fe8b5a54832db454d7a2585240d3