### PR TITLE
Fix wording in AI steps documentation

### DIFF
--- a/ai_steps.md
+++ b/ai_steps.md
@@ -1,7 +1,7 @@
 ```
 Please do the following:
 - Make a service the search a job from LinkedIn
-- Create a python script that scrap extract job listings from LinkedIn and other job boards. Push the script to the "job-search-bot" repo. Techniques: Utilize web scraping libraries such as BeautifulSoup (python) and Scrapy (python) to navigate and parse HTML/CSS content.
+- Create a python script that scrape and extract job listings from LinkedIn and other job boards. Push the script to the "job-search-bot" repo. Techniques: Utilize web scraping libraries such as BeautifulSoup (python) and Scrapy (python) to navigate and parse HTML/CSS content.
 - Now make a branch called feature scrap_page and make that fix and push the change
 - Make a merge against main with these changes
 - Add filter job listings based on user-defined criteria (location, role, company) and then push it up. Techniques: Implement a filtering system using natural language processing (NLP) techniques, such as tokenization and entity recognition (python).


### PR DESCRIPTION
## Summary
- clarify instruction to scrape and extract job listings in ai_steps.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895017c21d0832dab7d24254f5837c0