### PR TITLE
Load search criteria from config

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def main():
     with open(config_path, "r") as file:
         config = yaml.safe_load(file)
 
-    criteria = config["filter_criteria"]
+    criteria = config["search_criteria"]
 
     matching_jobs = job_filter.filter_jobs(criteria)
 


### PR DESCRIPTION
## Summary
- Use `search_criteria` key when loading config in `main.py` to match `config.yaml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950303c7d8832d8b436befb4bf0f32